### PR TITLE
Added framework to support twitter cards

### DIFF
--- a/opengraph.php
+++ b/opengraph.php
@@ -80,6 +80,14 @@ function opengraph_metadata() {
     $filter = 'opengraph_' . $property;
     $metadata["og:$property"] = apply_filters($filter, '');
   }
+
+  $twitter_properties = array('card');
+
+  foreach($twitter_properties as $property) {
+    $filter = 'twitter_' . $property;
+    $metadata["twitter:$property"] = apply_filters($filter, '');
+  }
+
   return apply_filters('opengraph_metadata', $metadata);
 }
 
@@ -106,6 +114,9 @@ function opengraph_default_metadata() {
 
   // additional article metadata
   add_filter('opengraph_metadata', 'opengraph_article_metadata');
+
+  // twitter card metadata
+  add_filter('twitter_card', 'twitter_default_card', 5);
 }
 add_filter('wp', 'opengraph_default_metadata');
 
@@ -257,6 +268,15 @@ function opengraph_default_locale( $locale ) {
     $locale = get_locale();
   }
   return $locale;
+}
+
+function twitter_default_card( $card ) {
+  $post_type = opengraph_default_type();
+  if($post_type == 'article') {
+    return "summary";
+  }
+
+  return '';
 }
 
 


### PR DESCRIPTION
Established the framework to support Twitter cards.  I only added the twitter:card property which will be set to summary if the opengraph_default_type == article.  This is the major tag that needs to be added to support Twitter cards, as the other properties fail over to the open graph equivalents or are optional.

Relevant Twitter documentation:
https://dev.twitter.com/docs/cards
https://dev.twitter.com/docs/cards/markup-reference
https://dev.twitter.com/docs/cards/validation/validator
