### PR TITLE
Prevent error with tribe_events - If tribe_events block editor is ena…

### DIFF
--- a/opengraph.php
+++ b/opengraph.php
@@ -313,7 +313,7 @@ function opengraph_block_image( $image = array() ) {
 	}
 
 	// Get the first image in the post content.
-	$blocks = parse_blocks( get_the_content( null, false ) );
+	$blocks = parse_blocks( get_the_content( null, false, false ) );
 	foreach ( $blocks as $block ) {
 		if ( count( $image ) >= opengraph_max_images() ) {
 			break;


### PR DESCRIPTION
Using Tribe Events and enable block edit - the event page is blank and a exception is happened in the logs:
```
PHP Fatal error:  Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given in /var/www/html/wp-includes/post-template.php:327\nStack trace:\n#0 /var/www/html/wp-includes/post-template.php(247): get_the_content('<span aria-labe...', false)\n#1 /var/www/html/wp-content/plugins/opengraph/opengraph.php(318): the_content(NULL, false, NULL)\
```

This is a small workaround which fixed it for me...